### PR TITLE
http 통신에 targetBranch 쿼리 파라미터 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subdeploy",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subdeploy",
-  "version": "1.0.5",
+  "version": "1.0.5-beta.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subdeploy",
-  "version": "1.0.8-beta.0",
+  "version": "1.0.8",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subdeploy",
-  "version": "1.0.5-beta.0",
+  "version": "1.0.8-beta.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -194,6 +194,12 @@ export class InvokeCommand implements yargs.CommandModule {
 
   builder(args: yargs.Argv) {
     return args
+      .option('b', {
+        alias: 'branch',
+        demandOption: false,
+        describe: 'The name of target branch. Automatically switch to target branch if this option will be provided.',
+        type: 'string',
+      })
       .positional('script', {
         describe:
           'The name of the script to run, the script file must exist in deploy-scripts directory',
@@ -205,10 +211,11 @@ export class InvokeCommand implements yargs.CommandModule {
   async handler(args: yargs.Arguments) {
     const { SUBDEPLOY_PORT, SUBDEPLOY_HOST, SUBDEPLOY_KEY } = process.env
     const script = args.script as string
+    const branch = args.branch as string | undefined
     const url = `http://${SUBDEPLOY_HOST}:${SUBDEPLOY_PORT}/exec`
     try {
       const { data } = await axios.post(url, null, {
-        params: { key: SUBDEPLOY_KEY, command: script },
+        params: { key: SUBDEPLOY_KEY, command: script, targetBranch: branch },
         headers: {
           'Content-Type': 'application/json',
         },

--- a/src/lib/generateWebSocketData.ts
+++ b/src/lib/generateWebSocketData.ts
@@ -1,0 +1,7 @@
+import { WebSocketData } from '../types/WebSocketData'
+
+function generateWebSocketData(payload: WebSocketData) {
+    return JSON.stringify(payload)
+}
+
+export default generateWebSocketData

--- a/src/lib/gitSwitch.ts
+++ b/src/lib/gitSwitch.ts
@@ -1,0 +1,8 @@
+import childProcess from 'child_process'
+
+function gitSwitch(branch: string) {
+    childProcess.execSync('git fetch --all')
+    childProcess.execSync(`git switch ${branch}`)
+}
+
+export default gitSwitch

--- a/src/lib/parseWebSocketData.ts
+++ b/src/lib/parseWebSocketData.ts
@@ -1,0 +1,8 @@
+import WebSocket from 'ws'
+import { WebSocketData } from '../types/WebSocketData'
+
+function parseWebSocketData(data: WebSocket.RawData) {
+    return JSON.parse(data.toString()) as WebSocketData
+}
+
+export default parseWebSocketData

--- a/src/types/WebSocketData.ts
+++ b/src/types/WebSocketData.ts
@@ -1,0 +1,4 @@
+export interface WebSocketData {
+    command: string
+    targetBranch?: string
+}


### PR DESCRIPTION
http 통신에 targetBranch 쿼리 파라미터 추가

- https://github.com/laftel-team/laftel-web/pull/675
상위 PR과 함께 보면 좋습니다.

### 이것을 머지하고 해야 할 일
* npm publish (1.0.8) / tag 및 release-note 작성
* vite-ssr 서버들에 모두 yarn global add subdeploy@1.0.8 로 최신 업데이트 해줘야함
* laftel-web에 enhance/subdeploy-switch 메인으로 머지
